### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/nixos/networking/default.nix
+++ b/nixos/networking/default.nix
@@ -52,7 +52,7 @@ in
       };
     };
 
-    # https://nixos.wiki/wiki/Systemd-networkd#network-online.target
+    # https://wiki.nixos.org/wiki/Systemd-networkd#network-online.target
     systemd.network.wait-online.anyInterface = true;
 
     users.extraUsers.tcpcryptd.group = "tcpcryptd";


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️